### PR TITLE
Fix constants compiler error on clang

### DIFF
--- a/include/bitcoin/system/constants.hpp
+++ b/include/bitcoin/system/constants.hpp
@@ -23,6 +23,7 @@
 /// DELETECSTDINT
 #include <limits>
 #include <bitcoin/system/types.hpp>
+#include <bit>
 
 namespace libbitcoin {
 


### PR DESCRIPTION
std::endian requires <bit>