### PR TITLE
Fix pragma and alignas constexpr for GCC/Clang

### DIFF
--- a/include/bitcoin/system/crypto/sha256.hpp
+++ b/include/bitcoin/system/crypto/sha256.hpp
@@ -114,7 +114,7 @@ constexpr auto half = to_bits(digest_size) >> byte_bits; // bit count >> 8
 
 /// Padding for full block hash round (64 bytes of pad/count).
 /// The buffer is prefilled with padding and a count of 512 bits.
-constexpr alignas(16) block pad_64
+alignas(16) constexpr block pad_64
 {
     pppp, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -129,7 +129,7 @@ constexpr alignas(16) block pad_64
 
 /// Padding for a half block hash round (32 bytes of pad/count).
 /// The buffer is prefilled with padding and a count of 256 bits.
-constexpr alignas(16) block pad_32
+alignas(16) constexpr block pad_32
 {
     xxxx, xxxx, xxxx, xxxx, xxxx, xxxx, xxxx, xxxx,
     xxxx, xxxx, xxxx, xxxx, xxxx, xxxx, xxxx, xxxx,

--- a/include/bitcoin/system/define.hpp
+++ b/include/bitcoin/system/define.hpp
@@ -46,10 +46,11 @@ namespace bc = libbitcoin;
 #define BC_USER_AGENT "/libbitcoin:" LIBBITCOIN_SYSTEM_VERSION "/"
 
 /// Emit messages from .cpp during compilation.
+#define DO_PRAGMA(text) _Pragma (#text)
 #if defined(HAVE_MSC)
     #define DEFINED(text) __pragma(message("defined: " text))
 #elif defined(HAVE_GNUC)
-    #define DEFINED(text) _Pragma("message defined: " text)
+    #define DEFINED(text) DO_PRAGMA(message ("defined: " #text))
 #endif
 
 #ifdef NDEBUG

--- a/include/bitcoin/system/impl/crypto/sha_algorithm.ipp
+++ b/include/bitcoin/system/impl/crypto/sha_algorithm.ipp
@@ -564,7 +564,7 @@ constexpr auto half = to_bits(digest_size) >> byte_bits; // bit count >> 8
 
 /// Padding for full block hash round (64 bytes of pad/count).
 /// The buffer is prefilled with padding and a count of 512 bits.
-constexpr alignas(16) block merkle_pad64
+alignas(16) constexpr block merkle_pad64
 {
     pppp, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -579,7 +579,7 @@ constexpr alignas(16) block merkle_pad64
 
 /// Padding for a half block hash round (32 bytes of pad/count).
 /// The buffer is prefilled with padding and a count of 256 bits.
-constexpr alignas(16) block merkle_pad32
+alignas(16) constexpr block merkle_pad32
 {
     xxxx, xxxx, xxxx, xxxx, xxxx, xxxx, xxxx, xxxx,
     xxxx, xxxx, xxxx, xxxx, xxxx, xxxx, xxxx, xxxx,

--- a/src/crypto/sha256/sha256_2_shani.cpp
+++ b/src/crypto/sha256/sha256_2_shani.cpp
@@ -38,7 +38,7 @@ using namespace i128;
 
 #ifndef VISUAL
 
-constexpr alignas(mint128_t) uint8_t mask[sizeof(mint128_t)]
+alignas(mint128_t) constexpr uint8_t mask[sizeof(mint128_t)]
 {
     0x03, 0x02, 0x01, 0x00, // 0x00010203ul
     0x07, 0x06, 0x05, 0x04, // 0x04050607ul
@@ -46,7 +46,7 @@ constexpr alignas(mint128_t) uint8_t mask[sizeof(mint128_t)]
     0x0f, 0x0e, 0x0d, 0x0c  // 0x0c0d0e0ful
 };
 
-constexpr alignas(mint128_t) uint8_t initial0[sizeof(mint128_t)]
+alignas(mint128_t) constexpr uint8_t initial0[sizeof(mint128_t)]
 {
     0x8c, 0x68, 0x05, 0x9b, // 0x9b05688cul
     0x7f, 0x52, 0x0e, 0x51, // 0x510e527ful
@@ -54,7 +54,7 @@ constexpr alignas(mint128_t) uint8_t initial0[sizeof(mint128_t)]
     0x67, 0xe6, 0x09, 0x6a  // 0x6a09e667ul
 };
 
-constexpr alignas(mint128_t) uint8_t initial1[sizeof(mint128_t)]
+alignas(mint128_t) constexpr uint8_t initial1[sizeof(mint128_t)]
 {
     0x19, 0xcd, 0xe0, 0x5b, // 0x5be0cd19ul
     0xab, 0xd9, 0x83, 0x1f, // 0x1f83d9abul

--- a/src/crypto/sha256/sha256_4_sse4.cpp
+++ b/src/crypto/sha256/sha256_4_sse4.cpp
@@ -75,7 +75,7 @@ void merkle_sse4(digest1&, const block1&) NOEXCEPT
 
 void hash_sse4(state& state, const block1& blocks) NOEXCEPT
 {
-    constexpr alignas(16) uint32_t k256[]
+    alignas(16) constexpr uint32_t k256[]
     {
         0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
         0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
@@ -95,17 +95,17 @@ void hash_sse4(state& state, const block1& blocks) NOEXCEPT
         0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
     };
 
-    constexpr alignas(16) uint32_t flip_mask[]
+    alignas(16) constexpr uint32_t flip_mask[]
     {
         0x00010203, 0x04050607, 0x08090a0b, 0x0c0d0e0f
     };
 
-    constexpr alignas(16) uint32_t shuffle_00ba[]
+    alignas(16) constexpr uint32_t shuffle_00ba[]
     {
         0x03020100, 0x0b0a0908, 0xffffffff, 0xffffffff
     };
 
-    constexpr alignas(16) uint32_t shuffle_dc00[]
+    alignas(16) constexpr uint32_t shuffle_dc00[]
     {
         0xffffffff, 0xffffffff, 0x03020100, 0x0b0a0908
     };


### PR DESCRIPTION
Small fixes for GCC

1. Pragma message works with string concatenation with clang
2. The `constexpr alignas` should be `alignas constexpr` with clang